### PR TITLE
x3.33 speedup with async I/O

### DIFF
--- a/ble-quaternions-listener/lines-per-second.sh
+++ b/ble-quaternions-listener/lines-per-second.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+tail -f motion_log.txt | { count=0; old=$(date +%s); while read line; do ((count++)); s=$(date +%s); if [ "$s" -ne "$old" ]; then echo "$count lines per second"; count=0; old=$s; fi; done; }

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -3,28 +3,33 @@ authors = ["Evgenii P. <eupn@protonmail.com>"]
 name = "tracksb"
 description = "A firmware for skateboard tracker board"
 edition = "2018"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
-axp173 = "0.1"
-bno080 = { git = "https://github.com/eupn/bno080.git" }
+heapless = "0.6"
+async-embedded-traits = "0.1"
+axp173 = { git = "https://github.com/eupn/axp173-rs.git", branch = "async-api" }
+bno080 = { path = "../../bno080" } #{ git = "https://github.com/eupn/bno080.git" }
 bbqueue             = "0.4.12"
 bluetooth-hci       = { version = "0.1.0" }
-embassy = { git = "https://github.com/eupn/embassy.git", branch = "add-stm32wb55" }
-embassy-stm32wb55 = { git = "https://github.com/eupn/embassy.git", branch = "add-stm32wb55", features = ["55"] }
+embassy = { path = "../../embassy/embassy" }
+embassy-stm32wb55 = { path = "../../embassy/embassy-stm32wb55", features = ["55", "defmt"] }
+futures = { version = "0.3", default-features = false, features = ["async-await"] }
+#embassy = { git = "https://github.com/eupn/embassy.git", branch = "add-stm32wb55" }
+#embassy-stm32wb55 = { git = "https://github.com/eupn/embassy.git", branch = "add-stm32wb55", features = ["55"] }
 stm32wb55           = { git = "https://github.com/eupn/stm32wb55.git" }
 cortex-m = { version = "0.6.4" }
 cortex-m-rt = "0.6.13"
 cortex-m-rtic = "0.5"
-defmt = "0.1.2"
-defmt-rtt = "0.1.0"
-#embedded-hal = "1.0.0-alpha.4"
-nb                  = "1.0"
-panic-probe = { version = "0.1.0", features = ["print-defmt"] }
+defmt = "0.2"
+defmt-rtt = "0.2"
+nb = "1.0"
+panic-probe = { version = "0.2", features = ["print-defmt"] }
 panic-reset = "0.1.0"
-stm32wb-hal         = { version = "0.1.3", features = ["rt", "xG-package", "stm32-usbd"] }
+stm32wb-hal = { version = "0.1", features = ["rt", "xG-package", "stm32-usbd"] }
 usb-device = "0.2"
 usbd-serial = "0.1.0"
+if_chain = "1.0.1"
 
 # TODO: update to 1.0
 [dependencies.embedded-hal]
@@ -35,7 +40,7 @@ features = ["unproven"]
 # set logging levels here
 default = [
   "defmt-default",
-  # "dependency-a/defmt-trace",
+  # "embassy-stm32wb55/defmt-debug",
 ]
 
 defmt-default = []
@@ -56,8 +61,8 @@ overflow-checks = true # <-
 [profile.release]
 codegen-units = 1
 debug = 2
-debug-assertions = false # <-
+debug-assertions = true # <-
 incremental = false
 lto = 'fat'
 opt-level = 3 # <-
-overflow-checks = false # <-
+overflow-checks = true # <-

--- a/firmware/rustfmt.toml
+++ b/firmware/rustfmt.toml
@@ -1,1 +1,1 @@
-merge_imports = true
+imports_granularity = "crate"

--- a/firmware/src/bin/ble_quaternions.rs
+++ b/firmware/src/bin/ble_quaternions.rs
@@ -8,26 +8,38 @@
 
 use tracksb as _;
 
+use async_embedded_traits::delay::AsyncDelayMs;
 use core::cell::UnsafeCell;
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 use embassy::{
     executor::{task, Executor},
-    util::{Forever, Signal},
+    util::{Forever, InterruptFuture, Signal},
 };
-use embassy_stm32wb55::{ble::Ble, interrupt};
-use embedded_hal::blocking::delay::DelayMs;
+use embassy_stm32wb55::{
+    ble::Ble,
+    delay::{lptim1::LptimDelay as Lptim1Delay, lptim2::LptimDelay as Lptim2Delay},
+    i2c::i2c3::AsyncI2c as AsyncI2c3,
+};
+use heapless::{consts, spsc::Queue};
+use if_chain::if_chain;
 use stm32wb_hal::{
-    delay::DelayCM,
+    dma::{
+        dma1impl::{C1, C2},
+        DmaExt,
+    },
     flash::FlashExt,
     gpio::{ExtiPin, State},
     i2c::{Error as I2cError, I2c},
+    interrupt,
     ipcc::Ipcc,
+    lptim::{lptim1::LpTimer as LpTimer1, lptim2::LpTimer as LpTimer2},
     pac,
+    pac::{Peripherals, EXTI, I2C1, I2C3, SYSCFG},
     prelude::*,
     pwr,
     rcc::{
-        ApbDivider, Config, HDivider, HseDivider, PllConfig, PllSrc, Rcc, RfWakeupClock, RtcClkSrc,
-        StopWakeupClock, SysClkSrc,
+        ApbDivider, Config, HDivider, HseDivider, LptimClkSrc, PllConfig, PllSrc, Rcc,
+        RfWakeupClock, RtcClkSrc, StopWakeupClock, SysClkSrc,
     },
     rtc, stm32,
     tl_mbox::{shci::ShciBleInitCmdParam, TlMbox},
@@ -35,7 +47,10 @@ use stm32wb_hal::{
 use tracksb::{
     ble::{batt_service::BatteryService, motion_service::MotionService},
     bsp,
-    bsp::{ImuIntPin, PmicIntPin, Rgb},
+    bsp::{
+        ImuIntPin, ImuResetPin, ImuSclPin, ImuSdaPin, PmicI2cSclPin, PmicI2cSdaPin, PmicIntPin,
+        PullUpsPin, Rgb, IMU_I2C_SPEED,
+    },
     imu::{ImuWrapper, MotionData, IMU_REPORTING_INTERVAL_MS, IMU_REPORTING_RATE_HZ},
     pmic,
     pmic::{wait_init_pmic, ImuPowerState, Pmic},
@@ -57,30 +72,129 @@ static PMIC_INT_PIN: SyncWrapper<PmicIntPin> = SyncWrapper::new_none();
 static IMU: SyncWrapper<ImuWrapper<I2cError, bsp::ImuI2c, bsp::ImuResetPin>> =
     SyncWrapper::new_none();
 static IMU_INT_PIN: SyncWrapper<ImuIntPin> = SyncWrapper::new_none();
-static DELAY: SyncWrapper<DelayCM> = SyncWrapper::new_none();
+
+static PMIC_DELAY: SyncWrapper<Lptim1Delay> = SyncWrapper::new_none();
+static IMU_DELAY: SyncWrapper<Lptim2Delay> = SyncWrapper::new_none();
 
 static BLE: SyncWrapper<Ble> = SyncWrapper::new_none();
 static SERVICE: SyncWrapper<MotionService> = SyncWrapper::new_none();
 static BATT_SERVICE: SyncWrapper<BatteryService> = SyncWrapper::new_none();
 
 static BLE_READY_SIGNAL: Signal<()> = Signal::new();
+static MOTION_SIGNAL: Signal<()> = Signal::new();
 
-static MOTION_SIGNAL: Signal<MotionData> = Signal::new();
+static MOTION_DATA_QUEUE: SyncWrapper<
+    Queue<MotionData, consts::U32, u8, heapless::spsc::SingleCore>,
+> = SyncWrapper::new_none();
 
 #[task]
-async fn run_main(mbox: TlMbox, ipcc: Ipcc) {
+async fn run_main(mut rcc: Rcc, mbox: TlMbox, ipcc: Ipcc) {
+    defmt::info!("Running main");
+
+    let mut dp = unsafe { Peripherals::steal() };
+    let mut gpioa = dp.GPIOA.split(&mut rcc);
+    let red_led = gpioa.pa4.into_push_pull_output_with_state(
+        &mut gpioa.moder,
+        &mut gpioa.otyper,
+        State::High,
+    );
+    let green_led = gpioa.pa5.into_push_pull_output_with_state(
+        &mut gpioa.moder,
+        &mut gpioa.otyper,
+        State::High,
+    );
+    let blue_led = gpioa.pa6.into_push_pull_output_with_state(
+        &mut gpioa.moder,
+        &mut gpioa.otyper,
+        State::High,
+    );
+    let rgb_led = RgbLed::new(red_led, green_led, blue_led);
+    unsafe { &mut *RGB.0.get() }.replace(rgb_led);
+
+    let mut gpiob = dp.GPIOB.split(&mut rcc);
+    let dma_channels = dp.DMA1.split(&mut rcc, dp.DMAMUX1);
+    let pull_ups = gpiob
+        .pb5
+        .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
+    let pmic_scl = gpiob
+        .pb6
+        .into_floating_input(&mut gpiob.moder, &mut gpiob.pupdr);
+    let pmic_sda = gpiob
+        .pb7
+        .into_floating_input(&mut gpiob.moder, &mut gpiob.pupdr);
+    let pmic_scl = pmic_scl.into_open_drain_output(&mut gpiob.moder, &mut gpiob.otyper);
+    let pmic_scl = pmic_scl.into_af4(&mut gpiob.moder, &mut gpiob.afrl);
+    let pmic_sda = pmic_sda.into_open_drain_output(&mut gpiob.moder, &mut gpiob.otyper);
+    let pmic_sda = pmic_sda.into_af4(&mut gpiob.moder, &mut gpiob.afrl);
+    let pmic_int_pin = gpiob
+        .pb1
+        .into_pull_up_input(&mut gpiob.moder, &mut gpiob.pupdr);
+    init_pmic(
+        dp.I2C1,
+        dma_channels.ch1,
+        pull_ups,
+        pmic_scl,
+        pmic_sda,
+        pmic_int_pin,
+        &mut rcc,
+        &mut dp.SYSCFG,
+        &mut dp.EXTI,
+    )
+    .await;
+
+    let imu_rst = gpioa
+        .pa15
+        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper);
+    let imu_int_pin = gpiob
+        .pb3
+        .into_pull_up_input(&mut gpiob.moder, &mut gpiob.pupdr);
+    let imu_scl = gpioa
+        .pa7
+        .into_open_drain_output(&mut gpioa.moder, &mut gpioa.otyper);
+    let imu_scl = imu_scl.into_af4(&mut gpioa.moder, &mut gpioa.afrl);
+    let imu_sda = gpiob
+        .pb4
+        .into_open_drain_output(&mut gpiob.moder, &mut gpiob.otyper);
+    let imu_sda = imu_sda.into_af4(&mut gpiob.moder, &mut gpiob.afrl);
+    init_imu(
+        dp.I2C3,
+        dma_channels.ch2,
+        imu_rst,
+        imu_int_pin,
+        imu_scl,
+        imu_sda,
+        &mut rcc,
+        &mut dp.SYSCFG,
+        &mut dp.EXTI,
+    )
+    .await;
+
+    let pmic_delay = unsafe { &mut *PMIC_DELAY.0.get() };
+    let rgb_led = unsafe { &mut *RGB.0.get() };
+    if let Some(pmic_delay) = pmic_delay {
+        if let Some(rgb_led) = rgb_led {
+            startup_animate(rgb_led, pmic_delay).await;
+        }
+    }
+
+    defmt::info!(
+        "Initialized PMIC, MCU at {} MHz and IMU at {} Hz",
+        rcc.clocks.sysclk().0 / 1000,
+        IMU_REPORTING_RATE_HZ
+    );
+
     let config = ShciBleInitCmdParam {
         p_ble_buffer_address: 0,
         ble_buffer_size: 0,
         num_attr_record: 68,
         num_attr_serv: 8,
         attr_value_arr_size: 4096,
-        num_of_links: 8,
+        num_of_links: 2,
         extended_packet_length_enable: 1,
         pr_write_list_size: 0x3A,
-        mb_lock_count: 0x79,
-        att_mtu: 156,
-        slave_sca: 500,
+        mb_lock_count: 0x80,
+        att_mtu: 1024,
+        slave_sca: 100,
         master_sca: 0,
         ls_source: 1,
         max_conn_event_length: 0xFFFFFFFF,
@@ -92,6 +206,7 @@ async fn run_main(mbox: TlMbox, ipcc: Ipcc) {
 
     defmt::info!("Initializing BLE");
 
+    use embassy_stm32wb55::interrupt;
     let mut ble = Ble::init(
         interrupt::take!(IPCC_C1_RX_IT),
         interrupt::take!(IPCC_C1_TX_IT),
@@ -127,24 +242,214 @@ async fn run_main(mbox: TlMbox, ipcc: Ipcc) {
     loop {
         let ble = unsafe { &mut *BLE.0.get() };
         if let Some(ble) = ble {
-            let motion_data = MOTION_SIGNAL.wait().await;
-            if ble.has_events() {
-                tracksb::ble::process_event(ble).await.unwrap();
-            }
-            let service = unsafe { &mut *SERVICE.0.get() };
-            if let Some(service) = service {
-                service.update(ble, &motion_data).await.unwrap();
+            let mut motion_data = None;
+            {
+                let motion_signal_fut = MOTION_SIGNAL.wait();
+                let events_fut = tracksb::ble::process_event(ble);
+                futures::pin_mut!(events_fut);
+
+                match futures::future::select(motion_signal_fut, events_fut).await {
+                    futures::future::Either::Left(_) => {
+                        let motion_data_queue = unsafe { &mut *MOTION_DATA_QUEUE.0.get() };
+                        if let Some(motion_data_queue) = motion_data_queue {
+                            motion_data = motion_data_queue.dequeue();
+                        }
+                    }
+                    futures::future::Either::Right((e, _)) => {
+                        e.unwrap();
+                    }
+                }
             }
 
+            if_chain! {
+                if let Some(motion_data) = motion_data;
+                let service = unsafe { &mut *SERVICE.0.get() };
+                if let Some(service) = service;
+                then {
+                    service.update(ble, &motion_data).await.unwrap();
+                }
+            }
+
+            /*
             let batt_service = unsafe { &mut *BATT_SERVICE.0.get() };
             let pmic = unsafe { &mut *PMIC.0.get() };
             if let Some(pmic) = pmic {
                 if let Some(batt_service) = batt_service {
-                    let level = pmic.battery_level().unwrap();
+                    let level = pmic.battery_level().await.unwrap();
                     batt_service.update(ble, level as u8).await.unwrap();
+                }
+            }*/
+        }
+    }
+}
+
+async fn init_pmic(
+    i2c1: I2C1,
+    dma_c1: C1,
+    mut pull_ups: PullUpsPin,
+    scl: PmicI2cSclPin,
+    sda: PmicI2cSdaPin,
+    pmic_int_pin: PmicIntPin,
+    mut rcc: &mut Rcc,
+    syscfg: &mut SYSCFG,
+    exti: &mut EXTI,
+) {
+    let pmic_delay = unsafe { &mut *PMIC_DELAY.0.get() };
+    if let Some(pmic_delay) = pmic_delay {
+        // I2C pull-ups are controlled via pin
+        let _ = pull_ups.set_high();
+        let mut pmic = wait_init_pmic(i2c1, dma_c1, scl, sda, &mut rcc, pmic_delay).await;
+        pmic.set_imu_power(true).await.unwrap();
+        let pmic_int_pin = bsp::init_pmic_interrupt(pmic_int_pin, syscfg, exti);
+
+        unsafe { &mut *PMIC_INT_PIN.0.get() }.replace(pmic_int_pin);
+        unsafe { &mut *PMIC.0.get() }.replace(pmic);
+    }
+}
+
+async fn init_imu(
+    i2c3: I2C3,
+    dma_c2: C2,
+    imu_rst_pin: ImuResetPin,
+    imu_int_pin: ImuIntPin,
+    imu_scl_pin: ImuSclPin,
+    imu_sda_pin: ImuSdaPin,
+    mut rcc: &mut Rcc,
+    syscfg: &mut SYSCFG,
+    exti: &mut EXTI,
+) {
+    let imu_delay = unsafe { &mut *IMU_DELAY.0.get() };
+    if let Some(imu_delay) = imu_delay {
+        let i2c3 = I2c::i2c3(i2c3, (imu_scl_pin, imu_sda_pin), IMU_I2C_SPEED, &mut rcc);
+        use embassy_stm32wb55::interrupt;
+        let async_i2c3 = AsyncI2c3::new(
+            cortex_m::singleton!(: [u8; 1024] = [0; 1024]).unwrap(),
+            i2c3,
+            interrupt::take!(I2C3_EV),
+            interrupt::take!(I2C3_ER),
+            interrupt::take!(DMA1_CHANNEL2),
+            dma_c2,
+        );
+
+        let mut imu = ImuWrapper::new(async_i2c3, imu_rst_pin);
+        imu.reset_imu(imu_delay).await;
+        unsafe { &mut *IMU.0.get() }.replace(imu);
+
+        let imu_int_pin = bsp::init_imu_interrupt(imu_int_pin, syscfg, exti);
+        unsafe { &mut *IMU_INT_PIN.0.get() }.replace(imu_int_pin);
+    }
+}
+
+/// IMU interrupt handler task (EXTI3)
+#[task]
+async fn imu_int() {
+    use embassy_stm32wb55::interrupt;
+    let mut imu_int = interrupt::take!(EXTI3);
+
+    loop {
+        InterruptFuture::new(&mut imu_int).await;
+
+        let int_pin = unsafe { &mut *IMU_INT_PIN.0.get() };
+        if let Some(int_pin) = int_pin {
+            if int_pin.check_interrupt() {
+                int_pin.clear_interrupt_pending_bit();
+            }
+        }
+
+        if_chain! {
+            let pmic = unsafe { &mut *PMIC.0.get() };
+            let imu = unsafe { &mut *IMU.0.get() };
+            let delay = unsafe { &mut *IMU_DELAY.0.get() };
+            let rgb_led = unsafe { &mut *RGB.0.get() };
+            let motion_data_queue = unsafe { &mut *MOTION_DATA_QUEUE.0.get() };
+            if let Some(pmic) = pmic;
+            if let Some(imu) = imu;
+            if let Some(delay) = delay;
+            if let Some(rgb_led) = rgb_led;
+            if let Some(motion_data_queue) = motion_data_queue;
+            then {
+                // Ignore interrupts if IMU isn't enabled
+                if !pmic.imu_enabled().unwrap() {
+                    defmt::info!("IMU isn't enabled");
+                    continue;
+                }
+
+                // Initialize the IMU if it just booted up
+                if !imu.is_initialized() {
+                    defmt::info!("BNO08x booted, initializing...");
+                    imu.init_imu(delay, IMU_REPORTING_INTERVAL_MS).await;
+                    defmt::info!("BNO08x initialized");
+                } else {
+                    rgb_led.toggle(LedColor::Green);
+                    if let Some(motion_data) = imu.motion_data(delay).await.unwrap() {
+                        motion_data_queue.enqueue(motion_data).ok();
+                        MOTION_SIGNAL.signal(());
+                    }
                 }
             }
         }
+    }
+}
+
+/// PMIC interrupt handler task (EXTI1)
+#[task]
+async fn pmic_int() {
+    use embassy_stm32wb55::interrupt;
+    let mut pmic_int = interrupt::take!(EXTI1);
+
+    loop {
+        InterruptFuture::new(&mut pmic_int).await;
+
+        let int_pin = unsafe { &mut *PMIC_INT_PIN.0.get() };
+        if let Some(int_pin) = int_pin {
+            if int_pin.check_interrupt() {
+                int_pin.clear_interrupt_pending_bit();
+            }
+        }
+
+        if_chain! {
+            let pmic = unsafe { &mut *PMIC.0.get() };
+            if let Some(pmic) = pmic;
+            let imu_power_state = pmic.process_irqs().await.unwrap();
+            let imu = unsafe { &mut *IMU.0.get() };
+            if let Some(imu) = imu;
+            let delay = unsafe { &mut *PMIC_DELAY.0.get() };
+            if let Some(delay) = delay;
+            then {
+                // Process IRQs and manage IMU power if it was a power button IRQ
+                match imu_power_state {
+                    ImuPowerState::Shutdown => imu_on_off(pmic, imu, delay, false).await,
+                    ImuPowerState::Enabled => imu_on_off(pmic, imu, delay, true).await,
+                    ImuPowerState::Unchanged => (),
+                }
+
+                pmic.show_current().await.unwrap();
+            }
+        }
+    }
+}
+
+async fn imu_on_off(
+    pmic: &mut Pmic<pmic::Initialized, I2cError, bsp::PmicI2c>,
+    imu: &mut ImuWrapper<I2cError, bsp::ImuI2c, bsp::ImuResetPin>,
+    delay: &mut impl AsyncDelayMs<u8>,
+    turn_on: bool,
+) {
+    if turn_on {
+        defmt::info!("Turning on");
+        pmic.set_imu_power(true).await.unwrap();
+        imu.reset_imu(delay).await;
+    } else {
+        defmt::info!("Shutting down");
+        imu.reset_imu(delay).await;
+        pmic.set_imu_power(false).await.unwrap();
+        imu.deinit();
+
+        let rgb_led = unsafe { &mut *RGB.0.get() };
+        if let Some(rgb_led) = rgb_led {
+            rgb_led.turn_off_all();
+        }
+        // TODO: put the MCU into deep sleep here (STOP1 mode, for example)
     }
 }
 
@@ -154,7 +459,7 @@ static EXECUTOR: Forever<Executor> = Forever::new();
 fn main() -> ! {
     defmt::info!("Starting");
 
-    let mut dp = stm32::Peripherals::take().unwrap();
+    let dp = stm32::Peripherals::take().unwrap();
     let _cp = cortex_m::peripheral::Peripherals::take().unwrap();
 
     // Allow using debugger and RTT during WFI/WFE (sleep)
@@ -188,7 +493,9 @@ fn main() -> ! {
             p: Some(3),
         })
         .rtc_src(RtcClkSrc::Lse)
-        .rf_wkp_sel(RfWakeupClock::Lse);
+        .rf_wkp_sel(RfWakeupClock::Lse)
+        .lptim1_src(LptimClkSrc::Lse)
+        .lptim2_src(LptimClkSrc::Lse);
 
     let mut rcc = rcc.apply_clock_config(clock_config, &mut dp.FLASH.constrain().acr);
 
@@ -199,203 +506,23 @@ fn main() -> ! {
     let mbox = TlMbox::tl_init(&mut rcc, &mut ipcc);
     pwr::set_cpu2(false);
 
-    let mut gpioa = dp.GPIOA.split(&mut rcc);
-    let mut gpiob = dp.GPIOB.split(&mut rcc);
-    let mut delay = DelayCM::new(rcc.clocks);
+    /* DELAYS */
+    use embassy_stm32wb55::interrupt;
+    let lp_timer1 = LpTimer1::init_oneshot(dp.LPTIM1, &mut rcc);
+    let lp_timer2 = LpTimer2::init_oneshot(dp.LPTIM2, &mut rcc);
+    let pmic_delay = Lptim1Delay::new(lp_timer1, interrupt::take!(LPTIM1));
+    let imu_delay = Lptim2Delay::new(lp_timer2, interrupt::take!(LPTIM2));
+    unsafe { &mut *IMU_DELAY.0.get() }.replace(imu_delay);
+    unsafe { &mut *PMIC_DELAY.0.get() }.replace(pmic_delay);
 
-    let red_led = gpioa.pa4.into_push_pull_output_with_state(
-        &mut gpioa.moder,
-        &mut gpioa.otyper,
-        State::High,
-    );
-    let green_led = gpioa.pa5.into_push_pull_output_with_state(
-        &mut gpioa.moder,
-        &mut gpioa.otyper,
-        State::High,
-    );
-    let blue_led = gpioa.pa6.into_push_pull_output_with_state(
-        &mut gpioa.moder,
-        &mut gpioa.otyper,
-        State::High,
-    );
-    let mut rgb_led = RgbLed::new(red_led, green_led, blue_led);
+    unsafe { &mut *MOTION_DATA_QUEUE.0.get() }.replace(unsafe { Queue::u8_sc() });
 
-    /* PMIC */
-
-    // I2C pull-ups are controlled via pin
-    let mut pull_ups = gpiob
-        .pb5
-        .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
-    let _ = pull_ups.set_high();
-    let scl = gpiob
-        .pb6
-        .into_floating_input(&mut gpiob.moder, &mut gpiob.pupdr);
-    let sda = gpiob
-        .pb7
-        .into_floating_input(&mut gpiob.moder, &mut gpiob.pupdr);
-    let scl = scl.into_open_drain_output(&mut gpiob.moder, &mut gpiob.otyper);
-    let scl = scl.into_af4(&mut gpiob.moder, &mut gpiob.afrl);
-    let sda = sda.into_open_drain_output(&mut gpiob.moder, &mut gpiob.otyper);
-    let sda = sda.into_af4(&mut gpiob.moder, &mut gpiob.afrl);
-    let mut pmic = wait_init_pmic(dp.I2C1, scl, sda, &mut rcc, &mut delay);
-    pmic.set_imu_power(true).unwrap();
-    let pmic_int_pin = bsp::init_pmic_interrupt(
-        gpiob
-            .pb1
-            .into_pull_up_input(&mut gpiob.moder, &mut gpiob.pupdr),
-        &mut dp.SYSCFG,
-        &mut dp.EXTI,
-    );
-
-    unsafe { &mut *PMIC_INT_PIN.0.get() }.replace(pmic_int_pin);
-
-    startup_animate(&mut rgb_led, &mut delay);
-
-    unsafe { &mut *PMIC.0.get() }.replace(pmic);
-    unsafe { &mut *RGB.0.get() }.replace(rgb_led);
-
-    /* IMU */
-
-    let mut imu_rst = gpioa
-        .pa15
-        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper);
-    imu_rst.set_low().unwrap();
-    delay.delay_ms(100_u16);
-    imu_rst.set_high().unwrap();
-
-    let imu_int_pin = bsp::init_imu_interrupt(
-        gpiob
-            .pb3
-            .into_pull_up_input(&mut gpiob.moder, &mut gpiob.pupdr),
-        &mut dp.SYSCFG,
-        &mut dp.EXTI,
-    );
-    unsafe { &mut *IMU_INT_PIN.0.get() }.replace(imu_int_pin);
-
-    let scl = gpioa
-        .pa7
-        .into_floating_input(&mut gpioa.moder, &mut gpioa.pupdr);
-    let scl = scl.into_open_drain_output(&mut gpioa.moder, &mut gpioa.otyper);
-    let scl = scl.into_af4(&mut gpioa.moder, &mut gpioa.afrl);
-    let sda = gpiob
-        .pb4
-        .into_open_drain_output(&mut gpiob.moder, &mut gpiob.otyper);
-    let sda = sda.into_af4(&mut gpiob.moder, &mut gpiob.afrl);
-    let i2c3 = I2c::i2c3(dp.I2C3, (scl, sda), 100.khz(), &mut rcc);
-
-    let imu = ImuWrapper::new(i2c3, imu_rst);
-    unsafe { &mut *IMU.0.get() }.replace(imu);
-    unsafe { &mut *DELAY.0.get() }.replace(delay);
-
-    defmt::info!(
-        "Initialized PMIC, MCU at {:u32} MHz and IMU at {:u16} Hz",
-        rcc.clocks.sysclk().0 / 1000,
-        IMU_REPORTING_RATE_HZ
-    );
-
-    let executor = EXECUTOR.put(Executor::new(cortex_m::asm::sev));
-    executor.spawn(run_main(mbox, ipcc)).unwrap();
-
-    loop {
-        executor.run();
-        cortex_m::asm::wfe();
-    }
-}
-
-fn poll_imu(imu: &mut ImuWrapper<I2cError, bsp::ImuI2c, bsp::ImuResetPin>) {
-    let delay = unsafe { &mut *DELAY.0.get() };
-    let rgb_led = unsafe { &mut *RGB.0.get() };
-
-    if let Some(delay) = delay {
-        if let Some(rgb_led) = rgb_led {
-            if let Some(motion_data) = imu.motion_data(delay).unwrap() {
-                rgb_led.toggle(LedColor::Green);
-                MOTION_SIGNAL.signal(motion_data);
-            }
-        }
-    }
-}
-
-#[interrupt]
-#[allow(non_snake_case)]
-fn EXTI3() {
-    let int_pin = unsafe { &mut *IMU_INT_PIN.0.get() };
-    if let Some(int_pin) = int_pin {
-        let pmic = unsafe { &mut *PMIC.0.get() };
-        if let Some(pmic) = pmic {
-            let imu = unsafe { &mut *IMU.0.get() };
-            if let Some(imu) = imu {
-                let delay = unsafe { &mut *DELAY.0.get() };
-                if let Some(delay) = delay {
-                    if int_pin.check_interrupt() {
-                        int_pin.clear_interrupt_pending_bit();
-
-                        // Ignore interrupts if IMU isn't enabled
-                        if !pmic.imu_enabled().unwrap() {
-                            return;
-                        }
-
-                        // Initialize the IMU if it just booted up
-                        if !imu.is_initialized() {
-                            defmt::info!("BNO08x booted, initializing...");
-                            imu.init_imu(delay, IMU_REPORTING_INTERVAL_MS);
-                        } else {
-                            poll_imu(imu);
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn imu_on_off(
-    imu: &mut ImuWrapper<I2cError, bsp::ImuI2c, bsp::ImuResetPin>,
-    delay: &mut impl DelayMs<u8>,
-    turn_on: bool,
-) {
-    if turn_on {
-        if !imu.is_initialized() {
-            imu.reset_imu(delay);
-        }
-    } else {
-        imu.deinit();
-        let rgb_led = unsafe { &mut *RGB.0.get() };
-        if let Some(rgb_led) = rgb_led {
-            rgb_led.turn_off_all();
-        }
-        // TODO: put the MCU into deep sleep
-    }
-}
-
-#[interrupt]
-#[allow(non_snake_case)]
-fn EXTI1() {
-    let int_pin = unsafe { &mut *PMIC_INT_PIN.0.get() };
-    if let Some(int_pin) = int_pin {
-        let pmic = unsafe { &mut *PMIC.0.get() };
-        if let Some(pmic) = pmic {
-            let imu = unsafe { &mut *IMU.0.get() };
-            if let Some(imu) = imu {
-                let delay = unsafe { &mut *DELAY.0.get() };
-                if let Some(delay) = delay {
-                    if int_pin.check_interrupt() {
-                        int_pin.clear_interrupt_pending_bit();
-
-                        // Process IRQs and manage IMU power if it was a power button IRQ
-                        let imu_power_state = pmic.process_irqs().unwrap();
-                        match imu_power_state {
-                            ImuPowerState::Shutdown => imu_on_off(imu, delay, false),
-                            ImuPowerState::Enabled => imu_on_off(imu, delay, true),
-                            ImuPowerState::Unchanged => (),
-                        }
-
-                        pmic.show_current().unwrap();
-                    }
-                }
-            }
-        }
-    }
+    let executor = EXECUTOR.put(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run_main(rcc, mbox, ipcc)).unwrap();
+        spawner.spawn(imu_int()).unwrap();
+        spawner.spawn(pmic_int()).unwrap();
+    });
 }
 
 #[exception]

--- a/firmware/src/ble.rs
+++ b/firmware/src/ble.rs
@@ -32,10 +32,7 @@ pub fn check_status(status: &Status<stm32wb55::event::Status>) -> bool {
     let success = matches!(status, Status::Success);
 
     if !success {
-        defmt::warn!(
-            "BLE non-success: {:?}",
-            defmt::Debug2Format::<defmt::consts::U128>(&status)
-        );
+        defmt::warn!("BLE non-success: {:?}", defmt::Debug2Format(&status));
     }
 
     success
@@ -169,10 +166,7 @@ pub async fn set_advertisement(enabled: bool, ble: &mut Ble) -> Result<(), BleEr
                     .map_err(|_| nb::Error::Other(()))
             })
             .await?;
-        defmt::info!(
-            "Adv: {:?}",
-            defmt::Debug2Format::<defmt::consts::U128>(&res)
-        );
+        defmt::info!("Adv: {:?}", defmt::Debug2Format(&res));
     } else {
         ble.perform_command(|rc| rc.set_nondiscoverable()).await?;
     }
@@ -184,17 +178,11 @@ pub async fn process_event(ble: &mut Ble) -> Result<(), BleError> {
     let event = ble.receive_event().await?;
     match event {
         Packet::Event(Event::ConnectionComplete(cc)) => {
-            defmt::info!(
-                "Connected: {:?}",
-                defmt::Debug2Format::<defmt::consts::U128>(&cc)
-            );
+            defmt::info!("Connected: {:?}", defmt::Debug2Format(&cc));
         }
 
         Packet::Event(Event::DisconnectionComplete(dc)) => {
-            defmt::info!(
-                "Disconnected: {:?}",
-                defmt::Debug2Format::<defmt::consts::U128>(&dc)
-            );
+            defmt::info!("Disconnected: {:?}", defmt::Debug2Format(&dc));
 
             set_advertisement(true, ble).await?;
         }
@@ -205,7 +193,7 @@ pub async fn process_event(ble: &mut Ble) -> Result<(), BleError> {
                 server_rx_mtu,
             },
         ))) => {
-            defmt::info!("Mtu changed to {:usize}", server_rx_mtu);
+            defmt::info!("Mtu changed to {}", server_rx_mtu);
         }
 
         Packet::Event(Event::Vendor(Stm32Wb5xEvent::GattAttributeModified(
@@ -214,10 +202,7 @@ pub async fn process_event(ble: &mut Ble) -> Result<(), BleError> {
             defmt::info!("Gatt attribute modified");
         }
 
-        _ => defmt::warn!(
-            "Unhandled event: {:?}",
-            defmt::Debug2Format::<defmt::consts::U256>(&event)
-        ),
+        _ => defmt::warn!("Unhandled event: {:?}", defmt::Debug2Format(&event)),
     }
 
     Ok(())

--- a/firmware/src/ble/motion_service.rs
+++ b/firmware/src/ble/motion_service.rs
@@ -68,18 +68,20 @@ impl MotionService {
     ) -> Result<(), super::BleError> {
         let binary_motion_data: MotionCharacteristicValue = motion_data.into();
 
-        ble.perform_command(|rc| {
-            let params = UpdateCharacteristicValueParameters {
-                service_handle: self.handle,
-                characteristic_handle: self.motion_char.handle,
-                offset: 0,
-                value: binary_motion_data.as_slice(),
-            };
+        let _result = ble
+            .perform_command(|rc| {
+                let params = UpdateCharacteristicValueParameters {
+                    service_handle: self.handle,
+                    characteristic_handle: self.motion_char.handle,
+                    offset: 0,
+                    value: binary_motion_data.as_slice(),
+                };
 
-            rc.update_characteristic_value(&params)
-                .map_err(|_| nb::Error::Other(()))
-        })
-        .await?;
+                rc.update_characteristic_value(&params)
+                    .map_err(|_| nb::Error::Other(()))
+            })
+            .await?;
+        // defmt::info!("{:?}", defmt::Debug2Format(&result));
 
         Ok(())
     }
@@ -126,10 +128,7 @@ impl MotionCharacteristic {
         ) = return_params
         {
             // TODO: check status
-            defmt::info!(
-                "Status: {:?}",
-                defmt::Debug2Format::<defmt::consts::U128>(&status)
-            );
+            defmt::info!("Status: {:?}", defmt::Debug2Format(&status));
             characteristic_handle
         } else {
             return Err(crate::ble::BleError::UnexpectedEvent);

--- a/firmware/src/imu.rs
+++ b/firmware/src/imu.rs
@@ -1,18 +1,17 @@
 use core::{convert::Infallible, marker::PhantomData};
 
+use async_embedded_traits::{
+    delay::AsyncDelayMs,
+    i2c::{AsyncI2cRead, AsyncI2cTransfer, AsyncI2cWrite, I2cAddress7Bit},
+};
 use bno080::{
     interface::I2cInterface,
     wrapper::{WrapperError, BNO080},
 };
-use embedded_hal::{
-    blocking::{
-        delay::DelayMs,
-        i2c::{Read, Write, WriteRead},
-    },
-    digital::v2::OutputPin,
-};
+use embassy_stm32wb55::i2c::StopDma;
+use embedded_hal::digital::v2::OutputPin;
 
-pub const IMU_REPORTING_RATE_HZ: u16 = 16;
+pub const IMU_REPORTING_RATE_HZ: u16 = 50;
 pub const IMU_REPORTING_INTERVAL_MS: u16 = 1000 / IMU_REPORTING_RATE_HZ;
 
 pub trait ImuState {}
@@ -23,20 +22,50 @@ impl ImuState for Initialized {}
 
 pub type Quaternion = [i16; 4];
 pub type Vec3 = [i16; 3];
-pub type ImuError<E> = WrapperError<bno080::Error<E, ()>>;
+pub type ImuError<E> = WrapperError<E>;
 
+pub trait AsyncI2c<E: core::fmt::Debug> = AsyncI2cRead<I2cAddress7Bit, Error = E>
+    + AsyncI2cTransfer<I2cAddress7Bit, Error = E>
+    + AsyncI2cWrite<I2cAddress7Bit, Error = E>
+    + StopDma;
+
+#[derive(Copy, Clone, Default)]
 pub struct MotionData {
     pub quat: Quaternion,
     pub accel: Vec3,
     pub gyro: Vec3,
 }
 
-pub enum ImuOrBus<
-    E: core::fmt::Debug,
-    I: Sized + Read<Error = E> + WriteRead<Error = E> + Write<Error = E>,
-> {
-    I2c(I),
-    Imu(Imu<Initialized, E, I>),
+pub enum ImuOrBusState {
+    I2c,
+    Imu,
+}
+
+pub struct ImuOrBus<E: core::fmt::Debug, I: Sized + AsyncI2c<E>> {
+    _e: PhantomData<E>,
+    pub state: ImuOrBusState,
+    pub imu: Option<Imu<Initialized, E, I>>,
+    pub bus: Option<I>,
+}
+
+impl<E: core::fmt::Debug, I: Sized + AsyncI2c<E>> ImuOrBus<E, I> {
+    pub fn i2c(i2c: I) -> Self {
+        Self {
+            _e: PhantomData,
+            state: ImuOrBusState::I2c,
+            imu: None,
+            bus: Some(i2c),
+        }
+    }
+
+    pub fn imu(imu: Imu<Initialized, E, I>) -> Self {
+        Self {
+            _e: PhantomData,
+            state: ImuOrBusState::Imu,
+            imu: Some(imu),
+            bus: None,
+        }
+    }
 }
 
 /// Holds reset pin and either initialized I2C bus or initialized IMU that consumes I2C bus.
@@ -44,37 +73,34 @@ pub enum ImuOrBus<
 /// from the uninitialized IMU chip that will trigger the IMU initialization.
 pub struct ImuWrapper<
     E: core::fmt::Debug,
-    I: Sized + Read<Error = E> + WriteRead<Error = E> + Write<Error = E>,
+    I: Sized + AsyncI2c<E>,
     RST: OutputPin<Error = Infallible>,
 > {
     reset_pin: RST,
     inner: ImuOrBus<E, I>,
 }
 
-impl<
-        E: core::fmt::Debug,
-        I: Sized + Read<Error = E> + WriteRead<Error = E> + Write<Error = E>,
-        RST: OutputPin<Error = Infallible>,
-    > ImuWrapper<E, I, RST>
+impl<E: core::fmt::Debug, I: Sized + AsyncI2c<E>, RST: OutputPin<Error = Infallible>>
+    ImuWrapper<E, I, RST>
 {
     pub fn new(i2c: I, reset_pin: RST) -> Self {
         Self {
             reset_pin,
-            inner: ImuOrBus::I2c(i2c),
+            inner: ImuOrBus::i2c(i2c),
         }
     }
 
     /// Call this from IMU's start-up interrupt handler to finish its initialization.
     /// It will internally convert itself from an I2C bus to an IMU that consumes it.
-    pub fn init_imu(&mut self, delay: &mut impl DelayMs<u8>, interval_ms: u16) {
-        if let ImuOrBus::I2c(i2c) = &mut self.inner {
+    pub async fn init_imu(&mut self, delay: &mut impl AsyncDelayMs<u8>, interval_ms: u16) {
+        if let ImuOrBusState::I2c = &mut self.inner.state {
             // Obtains an owned instance of an I2C that doesn't implement Copy
-            let owned_i2c = unsafe { core::ptr::read(i2c) };
+            let owned_i2c = unsafe { core::ptr::read(self.inner.bus.as_ref().unwrap()) };
 
             let imu = ImuBuilder::create(owned_i2c);
-            let imu = imu.init(delay, interval_ms).unwrap();
+            let imu = imu.init(delay, interval_ms).await.unwrap();
 
-            self.inner = ImuOrBus::Imu(imu);
+            self.inner = ImuOrBus::imu(imu);
         } else {
             // Shouldn't happen since each call to this function should prevent it from
             // being called again
@@ -84,11 +110,12 @@ impl<
 
     /// Call this to de-initialize the IMU and get an I2C port back.
     pub fn deinit(&mut self) {
-        if let ImuOrBus::Imu(imu) = &mut self.inner {
+        if let ImuOrBusState::Imu = &mut self.inner.state {
             // Obtains an owned instance of the IMU that doesn't implement Copy
-            let owned_imu = unsafe { core::ptr::read(imu) };
+            let owned_imu = unsafe { core::ptr::read(self.inner.imu.as_ref().unwrap()) };
 
-            self.inner = ImuOrBus::I2c(owned_imu.bno.free().free());
+            let async_i2c = owned_imu.bno.free();
+            self.inner = ImuOrBus::i2c(async_i2c);
         } else {
             // Shouldn't happen since each call to this function should prevent it from
             // being called again
@@ -96,91 +123,104 @@ impl<
         }
     }
 
-    pub fn reset_imu(&mut self, delay: &mut impl DelayMs<u8>) {
+    pub async fn reset_imu(&mut self, delay: &mut impl AsyncDelayMs<u8>) {
+        defmt::info!("Resetting IMU");
         self.reset_pin.set_low().unwrap();
-        delay.delay_ms(100);
+        delay.async_delay_ms(100).await;
         self.reset_pin.set_high().unwrap();
     }
 
     pub fn is_initialized(&self) -> bool {
-        matches!(self.inner, ImuOrBus::Imu(_))
+        matches!(self.inner.state, ImuOrBusState::Imu)
     }
 
-    pub fn motion_data(
+    pub async fn motion_data(
         &mut self,
-        delay: &mut impl DelayMs<u8>,
+        delay: &mut impl AsyncDelayMs<u8>,
     ) -> Result<Option<MotionData>, ImuError<E>> {
-        if let ImuOrBus::Imu(imu) = &mut self.inner {
-            Ok(imu.motion_data(delay)?)
+        if let ImuOrBusState::Imu = &mut self.inner.state {
+            Ok(if let Some(imu) = &mut self.inner.imu {
+                let data = imu.motion_data(delay).await?;
+                data
+            } else {
+                None
+            })
         } else {
             Ok(None)
         }
     }
+
+    pub async fn set_reporting_interval(&mut self, interval_ms: u16) -> Result<(), ImuError<E>> {
+        if let ImuOrBusState::Imu = &mut self.inner.state {
+            if let Some(imu) = &mut self.inner.imu {
+                imu.set_reporting_interval(interval_ms).await?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
-pub struct Imu<
-    S: ImuState,
-    E: core::fmt::Debug,
-    I: Read<Error = E> + WriteRead<Error = E> + Write<Error = E>,
-> {
+pub struct Imu<S: ImuState, E: core::fmt::Debug, I: AsyncI2c<E>> {
+    _e: PhantomData<E>,
     _s: PhantomData<S>,
-    bno: BNO080<I2cInterface<I>>,
+    bno: BNO080<E, I>,
 }
 
-pub struct ImuBuilder<
-    E: core::fmt::Debug,
-    I: Read<Error = E> + WriteRead<Error = E> + Write<Error = E>,
-> {
+pub struct ImuBuilder<E: core::fmt::Debug, I: AsyncI2c<E>> {
     _e: PhantomData<E>,
     _i: PhantomData<I>,
 }
 
-impl<E: core::fmt::Debug, I: Read<Error = E> + WriteRead<Error = E> + Write<Error = E>>
-    ImuBuilder<E, I>
-{
+impl<E: core::fmt::Debug, I: AsyncI2c<E>> ImuBuilder<E, I> {
     pub fn create(i2c: I) -> Imu<Created, E, I> {
         let i2c_interface = I2cInterface::default(i2c);
         let imu_driver = BNO080::new_with_interface(i2c_interface);
 
         Imu {
             _s: PhantomData,
+            _e: PhantomData,
             bno: imu_driver,
         }
     }
 }
 
-impl<E: core::fmt::Debug, I: Read<Error = E> + WriteRead<Error = E> + Write<Error = E>>
-    Imu<Created, E, I>
-{
-    pub fn init(
+impl<E: core::fmt::Debug, I: AsyncI2c<E>> Imu<Created, E, I> {
+    pub async fn init(
         mut self,
-        delay: &mut impl DelayMs<u8>,
+        delay: &mut impl AsyncDelayMs<u8>,
         interval_ms: u16,
     ) -> Result<Imu<Initialized, E, I>, ImuError<E>> {
-        self.bno.init(delay)?;
-        self.bno.enable_rotation_vector(interval_ms)?;
+        self.bno.init(delay).await?;
 
-        defmt::info!("Enabling accel");
-        self.bno.enable_linear_accel(interval_ms)?;
-
-        defmt::info!("Enabling gyro");
-        self.bno.enable_gyro(interval_ms)?;
-
-        Ok(Imu {
+        let mut imu = Imu::<Initialized, E, I> {
             _s: PhantomData,
+            _e: PhantomData,
             bno: self.bno,
-        })
+        };
+        imu.set_reporting_interval(interval_ms).await?;
+        Ok(imu)
     }
 }
 
-impl<E: core::fmt::Debug, I: Read<Error = E> + WriteRead<Error = E> + Write<Error = E>>
-    Imu<Initialized, E, I>
-{
-    pub fn motion_data(
+impl<E: core::fmt::Debug, I: AsyncI2c<E>> Imu<Initialized, E, I> {
+    pub async fn set_reporting_interval(&mut self, interval_ms: u16) -> Result<(), ImuError<E>> {
+        defmt::info!("Setting reporting interval at {} ms", interval_ms);
+
+        self.bno.enable_rotation_vector(interval_ms).await?;
+        defmt::info!("Enabling accel");
+        self.bno.enable_linear_accel(interval_ms).await?;
+        defmt::info!("Enabling gyro");
+        self.bno.enable_gyro(interval_ms).await?;
+
+        Ok(())
+    }
+
+    pub async fn motion_data(
         &mut self,
-        delay: &mut impl DelayMs<u8>,
+        delay: &mut impl AsyncDelayMs<u8>,
     ) -> Result<Option<MotionData>, ImuError<E>> {
-        let msg_count = self.bno.handle_all_messages(delay, 10u8);
+        let msg_count = self.bno.handle_all_messages(delay, 10u8).await;
         if msg_count > 0 {
             return Ok(Some(MotionData {
                 quat: self.bno.rotation_quaternion_fixed()?,

--- a/firmware/src/lib.rs
+++ b/firmware/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(trait_alias)]
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -6,8 +7,8 @@ use defmt_rtt as _; // global logger
 
 use stm32wb_hal as _; // memory layout
 
-use panic_reset as _;
-//use panic_probe as _;
+//use panic_reset as _;
+use panic_probe as _;
 
 pub mod ble;
 pub mod bsp;
@@ -22,13 +23,13 @@ fn panic() -> ! {
     cortex_m::asm::udf()
 }
 
-#[defmt::timestamp]
-fn timestamp() -> u64 {
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    // NOTE(no-CAS) `timestamps` runs with interrupts disabled
-    let n = COUNT.load(Ordering::Relaxed);
-    COUNT.store(n + 1, Ordering::Relaxed);
-    n as u64
+defmt::timestamp! {"{=u64}", {
+        static COUNT: AtomicUsize = AtomicUsize::new(0);
+        // NOTE(no-CAS) `timestamps` runs with interrupts disabled
+        let n = COUNT.load(Ordering::Relaxed);
+        COUNT.store(n + 1, Ordering::Relaxed);
+        n as u64
+    }
 }
 
 /// Terminates the application and makes `probe-run` exit with exit-code = 0

--- a/firmware/src/pmic.rs
+++ b/firmware/src/pmic.rs
@@ -1,20 +1,26 @@
 //! Power Management IC (AXP173) routines
 
-use crate::bsp;
+use crate::{bsp, bsp::PMIC_I2C_SPEED};
+use async_embedded_traits::{
+    delay::AsyncDelayMs,
+    i2c::{AsyncI2cTransfer, AsyncI2cWrite, I2cAddress7Bit},
+};
 use axp173::{
     AdcSampleRate, AdcSettings, Axp173, ChargingCurrent, Irq, Ldo, LdoKind, ShutdownLongPressTime,
     TsPinMode,
 };
 use core::marker::PhantomData;
-use embedded_hal::blocking::{
-    delay::DelayMs,
-    i2c::{Write, WriteRead},
-};
+use cortex_m::singleton;
+use embassy_stm32wb55::{i2c::i2c1::AsyncI2c as AsyncI2c1, interrupt};
+use embedded_hal::blocking::i2c::Read;
 use stm32wb_hal::{
+    dma::dma1impl::C1,
     i2c::{Error as I2cError, I2c},
     rcc::Rcc,
-    time::U32Ext,
 };
+
+pub trait AsyncI2c<E: core::fmt::Debug> =
+    AsyncI2cTransfer<I2cAddress7Bit, Error = E> + AsyncI2cWrite<I2cAddress7Bit, Error = E>;
 
 pub trait PmicState {}
 pub struct Created;
@@ -36,17 +42,18 @@ pub enum ImuPowerState {
     Unchanged,
 }
 
-pub struct Pmic<S: PmicState, E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> {
+pub struct Pmic<S: PmicState, E: core::fmt::Debug, I: AsyncI2c<E>> {
     axp173: Axp173<I>,
     state: S,
+    _e: PhantomData<E>,
 }
 
-pub struct PmicBuilder<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> {
+pub struct PmicBuilder<E: core::fmt::Debug, I: AsyncI2c<E>> {
     _e: PhantomData<E>,
     i2c: I,
 }
 
-impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> PmicBuilder<E, I> {
+impl<I: AsyncI2c<I2cError>> PmicBuilder<I2cError, I> {
     pub fn new(i2c: I) -> Self {
         Self {
             _e: PhantomData,
@@ -58,54 +65,55 @@ impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> PmicBuilde
         self.i2c
     }
 
-    pub fn check(&mut self) -> bool {
-        Axp173::check(&mut self.i2c)
-    }
-
-    pub fn build(self) -> Pmic<Created, E, I> {
+    pub fn build(self) -> Pmic<Created, I2cError, I> {
         let axp173 = Axp173::new(self.i2c);
 
         Pmic {
             axp173,
+            _e: PhantomData,
             state: Created,
         }
     }
 }
 
-impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> Pmic<Created, E, I> {
-    pub fn init(mut self) -> Result<Pmic<Initialized, E, I>, axp173::Error<E>> {
+impl<E: core::fmt::Debug, I: AsyncI2c<E>> Pmic<Created, E, I> {
+    pub async fn init(mut self) -> Result<Pmic<Initialized, E, I>, axp173::Error<E>> {
         // Check the presence of AXP173
-        self.axp173.init()?;
+        self.axp173.init().await?;
 
         // Set charging current to 100mA
         self.axp173
-            .set_charging_current(ChargingCurrent::CURRENT_100MA)?;
+            .set_charging_current(ChargingCurrent::CURRENT_100MA)
+            .await?;
 
         // 25Hz sample rate, Disable TS, enable current sensing ADC
-        self.axp173.set_adc_settings(
-            AdcSettings::default()
-                .set_adc_sample_rate(AdcSampleRate::RATE_25HZ)
-                .ts_adc(false)
-                .set_ts_pin_mode(TsPinMode::SHUT_DOWN)
-                .vbus_voltage_adc(true)
-                .vbus_current_adc(true)
-                .batt_voltage_adc(true)
-                .batt_current_adc(true),
-        )?;
+        self.axp173
+            .set_adc_settings(
+                AdcSettings::default()
+                    .set_adc_sample_rate(AdcSampleRate::RATE_25HZ)
+                    .ts_adc(false)
+                    .set_ts_pin_mode(TsPinMode::SHUT_DOWN)
+                    .vbus_voltage_adc(true)
+                    .vbus_current_adc(true)
+                    .batt_voltage_adc(true)
+                    .batt_current_adc(true),
+            )
+            .await?;
 
-        self.axp173.set_coulomb_counter(true)?;
-        self.axp173.resume_coulomb_counter()?;
+        self.axp173.set_coulomb_counter(true).await?;
+        self.axp173.resume_coulomb_counter().await?;
 
         self.axp173
-            .set_shutdown_long_press_time(ShutdownLongPressTime::SEC_4)?;
-        self.axp173.set_shutdown_long_press(false)?;
+            .set_shutdown_long_press_time(ShutdownLongPressTime::SEC_4)
+            .await?;
+        self.axp173.set_shutdown_long_press(false).await?;
 
-        self.axp173.disable_ldo(&LdoKind::LDO4)?;
+        self.axp173.disable_ldo(&LdoKind::LDO4).await?;
 
-        self.axp173.clear_all_irq()?;
-        self.enable_irqs()?;
+        self.axp173.clear_all_irq().await?;
+        self.enable_irqs().await?;
 
-        status(&mut self.axp173);
+        status(&mut self.axp173).await;
 
         Ok(Pmic {
             axp173: self.axp173,
@@ -116,31 +124,45 @@ impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> Pmic<Creat
                 ) as u32,
                 is_imu_enabled: false,
             },
+            _e: PhantomData,
         })
     }
 
     /// Enables interesting IRQs from PMIC.
-    fn enable_irqs(&mut self) -> Result<(), axp173::Error<E>> {
-        self.axp173.set_irq(axp173::Irq::ButtonLongPress, true)?;
-        self.axp173.set_irq(axp173::Irq::BatteryCharged, true)?;
-        self.axp173.set_irq(axp173::Irq::LowBatteryWarning, true)?;
-        self.axp173.set_irq(axp173::Irq::VbusPluggedIn, true)?;
-        self.axp173.set_irq(axp173::Irq::VbusUnplugged, true)?;
+    async fn enable_irqs(&mut self) -> Result<(), axp173::Error<E>> {
+        self.axp173
+            .set_irq(axp173::Irq::ButtonLongPress, true)
+            .await?;
+        self.axp173
+            .set_irq(axp173::Irq::BatteryCharged, true)
+            .await?;
+        self.axp173
+            .set_irq(axp173::Irq::LowBatteryWarning, true)
+            .await?;
+        self.axp173
+            .set_irq(axp173::Irq::VbusPluggedIn, true)
+            .await?;
+        self.axp173
+            .set_irq(axp173::Irq::VbusUnplugged, true)
+            .await?;
 
         Ok(())
     }
 }
 
-impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> Pmic<Initialized, E, I> {
-    pub fn set_imu_power(&mut self, enable: bool) -> Result<(), axp173::Error<E>> {
+impl<E: core::fmt::Debug, I: AsyncI2c<E>> Pmic<Initialized, E, I> {
+    pub async fn set_imu_power(&mut self, enable: bool) -> Result<(), axp173::Error<E>> {
+        defmt::info!("Setting IMU enabled: {}", enable);
         if enable {
             // Provide 2.8V for IMU via LDO3
-            self.axp173.enable_ldo(&Ldo::ldo3_with_voltage(10, true))?;
+            self.axp173
+                .enable_ldo(&Ldo::ldo3_with_voltage(10, true))
+                .await?;
         } else {
-            self.axp173.disable_ldo(&LdoKind::LDO3)?;
+            self.axp173.disable_ldo(&LdoKind::LDO3).await?;
         }
 
-        self.state.is_imu_enabled = self.axp173.read_ldo(LdoKind::LDO3)?.enabled();
+        self.state.is_imu_enabled = self.axp173.read_ldo(LdoKind::LDO3).await?.enabled();
 
         Ok(())
     }
@@ -149,68 +171,67 @@ impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> Pmic<Initi
         Ok(self.state.is_imu_enabled)
     }
 
-    /// Called from PMIC IRQ pin ISR. Checks IRQ flags and clears pending IRQs.
-    pub fn process_irqs(&mut self) -> Result<ImuPowerState, axp173::Error<E>> {
+    /// Checks IRQ flags and clears pending IRQs.
+    pub async fn process_irqs(&mut self) -> Result<ImuPowerState, axp173::Error<E>> {
+        defmt::info!("PMIC IRQ START");
         let mut imu_power_state = ImuPowerState::Unchanged;
 
-        if self.axp173.check_irq(Irq::ButtonLongPress)? {
-            self.axp173.clear_irq(Irq::ButtonLongPress)?;
+        if self.axp173.check_irq(Irq::ButtonLongPress).await? {
+            self.axp173.clear_irq(Irq::ButtonLongPress).await?;
 
             if self.imu_enabled()? {
-                defmt::info!("Shutting down");
-                self.set_imu_power(false)?;
                 imu_power_state = ImuPowerState::Shutdown;
             } else {
-                defmt::info!("Turning on");
-                self.set_imu_power(true)?;
                 imu_power_state = ImuPowerState::Enabled;
             }
         }
-        if self.axp173.check_irq(Irq::BatteryCharged)? {
-            self.axp173.clear_irq(Irq::BatteryCharged)?;
-            self.axp173.reset_coulomb_counter()?;
+        if self.axp173.check_irq(Irq::BatteryCharged).await? {
+            self.axp173.clear_irq(Irq::BatteryCharged).await?;
+            self.axp173.reset_coulomb_counter().await?;
         }
-        if self.axp173.check_irq(Irq::LowBatteryWarning)? {
-            self.axp173.clear_irq(Irq::LowBatteryWarning)?;
-            let discharge_coulombs = self.axp173.read_discharge_coulomb_counter()?;
-            defmt::info!("Low battery, discharge cc: {:u32}", discharge_coulombs);
+        if self.axp173.check_irq(Irq::LowBatteryWarning).await? {
+            self.axp173.clear_irq(Irq::LowBatteryWarning).await?;
+            let discharge_coulombs = self.axp173.read_discharge_coulomb_counter().await?;
+            defmt::info!("Low battery, discharge cc: {}", discharge_coulombs);
         }
-        if self.axp173.check_irq(Irq::VbusPluggedIn)? {
-            self.axp173.clear_irq(Irq::VbusPluggedIn)?;
+        if self.axp173.check_irq(Irq::VbusPluggedIn).await? {
+            self.axp173.clear_irq(Irq::VbusPluggedIn).await?;
             defmt::info!("USB charger plugged in");
         }
-        if self.axp173.check_irq(Irq::VbusUnplugged)? {
-            self.axp173.clear_irq(Irq::VbusUnplugged)?;
+        if self.axp173.check_irq(Irq::VbusUnplugged).await? {
+            self.axp173.clear_irq(Irq::VbusUnplugged).await?;
             defmt::info!("USB charger unplugged");
         }
 
         // Clear other possible IRQs otherwise we can't rely on the IRQ pin
-        self.axp173.clear_all_irq()?;
+        self.axp173.clear_all_irq().await?;
+
+        defmt::info!("PMIC IRQ FINISH");
 
         Ok(imu_power_state)
     }
 
     /// Shows battery discharge current for reference purposes.
-    pub fn show_current(&mut self) -> Result<(), axp173::Error<E>> {
-        let batt_discharge = self.axp173.batt_discharge_current()?;
+    pub async fn show_current(&mut self) -> Result<(), axp173::Error<E>> {
+        let batt_discharge = self.axp173.batt_discharge_current().await?;
         defmt::info!(
-            "Batt current consumption: {:f32} mA",
+            "Batt current consumption: {} mA",
             batt_discharge.as_milliamps()
         );
 
         Ok(())
     }
 
-    pub fn battery_level(&mut self) -> Result<u8, axp173::Error<E>> {
-        let _coulombs_out = self.axp173.read_discharge_coulomb_counter()?;
-        let mut coulombs_in = self.axp173.read_charge_coulomb_counter()?;
+    pub async fn battery_level(&mut self) -> Result<u8, axp173::Error<E>> {
+        let _coulombs_out = self.axp173.read_discharge_coulomb_counter().await?;
+        let mut coulombs_in = self.axp173.read_charge_coulomb_counter().await?;
 
         // Assume full battery if there's not enough charge coulombs
         if coulombs_in < self.state.charge_coulombs_default {
             coulombs_in = self.state.charge_coulombs_default + 1;
         }
 
-        let remaining_charge = self.axp173.estimate_charge_level(Some(coulombs_in))?;
+        let remaining_charge = self.axp173.estimate_charge_level(Some(coulombs_in)).await?;
         if let Some(remaining_charge) = remaining_charge {
             let level_pct = remaining_charge as f32 / DEFAULT_BATTERY_CAPACITY_MAH * 100_f32;
             let level_pct = (level_pct as u8).clamp(0, 100);
@@ -235,98 +256,109 @@ impl<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>> Pmic<Initi
 /// Waits for PMIC to power on.
 /// On the very first power-on the PMIC is shutdown by default.
 /// The long button press will power on the PMIC and it will become available on I2C.
-pub fn wait_init_pmic(
+pub async fn wait_init_pmic(
     mut i2c1: bsp::PmicI2cPort,
+    dma_c1: C1,
     mut scl: bsp::PmicI2cSclPin,
     mut sda: bsp::PmicI2cSdaPin,
     rcc: &mut Rcc,
-    delay: &mut impl DelayMs<u8>,
+    delay: &mut impl AsyncDelayMs<u8>,
 ) -> Pmic<Initialized, I2cError, bsp::PmicI2c> {
+    defmt::info!("Waiting for PMIC");
+
+    // TODO: use async check
     loop {
-        let i2c = I2c::i2c1(i2c1, (scl, sda), 100.khz(), rcc);
-
-        let mut pmic = PmicBuilder::new(i2c);
-        let pmic_check = pmic.check();
-
+        let mut i2c = I2c::i2c1(i2c1, (scl, sda), PMIC_I2C_SPEED, rcc);
+        let mut buf = [0; 1];
+        let pmic_check = i2c.read(0x34, &mut buf).is_ok();
         if pmic_check {
-            break pmic.build();
+            let async_i2c = AsyncI2c1::new(
+                singleton!(: [u8; 128] = [0; 128]).unwrap(),
+                i2c,
+                interrupt::take!(I2C1_EV),
+                interrupt::take!(I2C1_ER),
+                interrupt::take!(DMA1_CHANNEL1),
+                dma_c1,
+            );
+            break PmicBuilder::new(async_i2c).build();
         } else {
-            delay.delay_ms(100_u8);
+            delay.async_delay_ms(100_u8).await;
         }
-        let (i2c, (scl_pin, sda_pin)) = pmic.free().free();
+        let (i2c, (scl_pin, sda_pin)) = i2c.free();
         i2c1 = i2c;
         scl = scl_pin;
         sda = sda_pin;
     }
     .init()
+    .await
     .unwrap()
 }
 
-fn status<E: core::fmt::Debug, I: WriteRead<Error = E> + Write<Error = E>>(axp173: &mut Axp173<I>) {
+async fn status<E: core::fmt::Debug, I: AsyncI2c<E>>(axp173: &mut Axp173<I>) {
     // Is the device connected to the USB power supply?
-    if axp173.vbus_present().unwrap() {
+    if axp173.vbus_present().await.unwrap() {
         defmt::info!("VBUS is present");
     } else {
         defmt::info!("VBUS is not present");
     }
 
     // Is the battery connected to the device?
-    if axp173.battery_present().unwrap() {
+    if axp173.battery_present().await.unwrap() {
         defmt::info!("Battery is present");
     } else {
         defmt::info!("Battery is not present");
     }
 
     // Is the battery currently being charged?
-    if axp173.battery_charging().unwrap() {
+    if axp173.battery_charging().await.unwrap() {
         defmt::info!("Battery is charging");
     } else {
         defmt::info!("Battery is not charging");
     }
 
-    let vbus = axp173.vbus_voltage().unwrap();
-    defmt::info!("VBUS: {:f32}", vbus.as_volts());
+    let vbus = axp173.vbus_voltage().await.unwrap();
+    defmt::info!("VBUS: {}", vbus.as_volts());
 
-    let vbus = axp173.vbus_current().unwrap();
-    defmt::info!("VBUS current: {:f32} mA", vbus.as_milliamps());
+    let vbus = axp173.vbus_current().await.unwrap();
+    defmt::info!("VBUS current: {} mA", vbus.as_milliamps());
 
-    let batt = axp173.batt_voltage().unwrap();
-    defmt::info!("Batt: {:f32} V", batt.as_volts());
+    let batt = axp173.batt_voltage().await.unwrap();
+    defmt::info!("Batt: {} V", batt.as_volts());
 
-    let batt_charge = axp173.batt_charge_current().unwrap();
-    let batt_discharge = axp173.batt_discharge_current().unwrap();
+    let batt_charge = axp173.batt_charge_current().await.unwrap();
+    let batt_discharge = axp173.batt_discharge_current().await.unwrap();
     defmt::info!(
-        "Batt: ^ {:f32} mA | v {:f32} mA",
+        "Batt: ^ {} mA | v {} mA",
         batt_charge.as_milliamps(),
         batt_discharge.as_milliamps()
     );
 
     defmt::info!(
-        "Charge coulombs: {:u32}",
-        axp173.read_charge_coulomb_counter().unwrap()
+        "Charge coulombs: {}",
+        axp173.read_charge_coulomb_counter().await.unwrap()
     );
     defmt::info!(
-        "Discharge coulombs: {:u32}",
-        axp173.read_discharge_coulomb_counter().unwrap()
+        "Discharge coulombs: {}",
+        axp173.read_discharge_coulomb_counter().await.unwrap()
     );
 
-    let ldo = axp173.read_ldo(LdoKind::LDO2).unwrap();
+    let ldo = axp173.read_ldo(LdoKind::LDO2).await.unwrap();
     defmt::info!(
-        "LDO2: enabled: {:bool}, voltage: {:f32} V",
+        "LDO2: enabled: {}, voltage: {} V",
         ldo.enabled(),
         ldo.voltage().0 as f32 / 1000.0,
     );
 
-    let ldo = axp173.read_ldo(LdoKind::LDO3).unwrap();
+    let ldo = axp173.read_ldo(LdoKind::LDO3).await.unwrap();
     defmt::info!(
-        "LDO3: enabled: {:bool}, voltage: {:f32} V",
+        "LDO3: enabled: {}, voltage: {} V",
         ldo.enabled(),
         ldo.voltage().0 as f32 / 1000.0,
     );
 
-    let ldo = axp173.read_ldo(LdoKind::LDO4).unwrap();
+    let ldo = axp173.read_ldo(LdoKind::LDO4).await.unwrap();
     defmt::info!(
-        "LDO4: enabled: {:bool}, voltage: {:f32} V",
+        "LDO4: enabled: {}, voltage: {} V",
         ldo.enabled(),
         ldo.voltage().0 as f32 / 1000.0,
     );

--- a/firmware/src/rgbled.rs
+++ b/firmware/src/rgbled.rs
@@ -3,8 +3,8 @@
 use embedded_hal::digital::v2::OutputPin;
 
 use crate::bsp::Rgb;
+use async_embedded_traits::delay::AsyncDelayMs;
 use core::convert::Infallible;
-use embedded_hal::blocking::delay::DelayMs;
 
 // TODO: try PWM for RGB pins
 
@@ -94,7 +94,7 @@ impl<
 }
 
 /// RGB LED flashing for startup.
-pub fn startup_animate(rgb: &mut Rgb, delay: &mut impl DelayMs<u32>) {
+pub async fn startup_animate(rgb: &mut Rgb, delay: &mut impl AsyncDelayMs<u32>) {
     rgb.set(LedColor::Red, false);
     rgb.set(LedColor::Green, false);
     rgb.set(LedColor::Blue, false);
@@ -105,6 +105,6 @@ pub fn startup_animate(rgb: &mut Rgb, delay: &mut impl DelayMs<u32>) {
         } else {
             LedColor::Green
         });
-        delay.delay_ms(50);
+        delay.async_delay_ms(50).await;
     }
 }

--- a/tracksbvis/tracksbvis.pde
+++ b/tracksbvis/tracksbvis.pde
@@ -71,7 +71,7 @@ void setup()
   accel_plot.getXAxis().setAxisLabelText("time");
   accel_plot.getYAxis().setAxisLabelText("m/s^2");
   accel_plot.activatePanning();
-  accel_plot.setYLim(-10, 10);
+  accel_plot.setYLim(-30, 30);
   accel_plot.addLayer("x", new GPointsArray());
   accel_plot.getLayer("x").setPointColor(color(0, 0, 255));
   accel_plot.addLayer("y", new GPointsArray());
@@ -89,7 +89,7 @@ void setup()
   gyro_plot.getXAxis().setAxisLabelText("time");
   gyro_plot.getYAxis().setAxisLabelText("rad/s");
   gyro_plot.activatePanning();
-  gyro_plot.setYLim(-10, 10);
+  gyro_plot.setYLim(-30, 30);
   gyro_plot.addLayer("x", new GPointsArray());
   gyro_plot.getLayer("x").setPointColor(color(0, 0, 255));
   gyro_plot.addLayer("y", new GPointsArray());


### PR DESCRIPTION
* Switch from blocking I2C to `async/.await`-friendly with DMA
* Switch delays from blocking to more efficient and `async` LPTIM-based delays
* Update `defmt` to `0.2`